### PR TITLE
fix: delete read_states of thread on its deletion

### DIFF
--- a/forum/backends/mongodb/threads.py
+++ b/forum/backends/mongodb/threads.py
@@ -24,6 +24,7 @@ class CommentThread(BaseContents):
         get_handler_by_name("comment_thread_deleted").send(
             sender=self.__class__, comment_thread_id=_id
         )
+        Users().delete_read_state_by_thread_id(_id)
         return result
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,13 @@ def patch_mongo_migration_database(monkeypatch: pytest.MonkeyPatch) -> Database[
         lambda *args: db,
     )
     return db
+
+
+@pytest.fixture(autouse=True)
+def patched_mongo_backend(monkeypatch: pytest.MonkeyPatch) -> Generator[Any, Any, Any]:
+    """Return the patched mongo_backend function for Mongo backend."""
+    monkeypatch.setattr(
+        "forum.backend.is_mysql_backend_enabled",
+        lambda course_id: False,
+    )
+    yield MongoBackend


### PR DESCRIPTION
- Management command throws an error for deleted threads whose read_states still exists in the Users collection. Although it's a replica of V1(cs_comment_service) which was also keeping the read_states of deleted threads. This commit will delete the read_states of the thread from User Collection on thread deletion as keeping the read_states are of no use.
