### PR TITLE
fix: don't override forum url if already defined

### DIFF
--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/forum/settings/common.py
+++ b/forum/settings/common.py
@@ -26,14 +26,21 @@ def plugin_settings(settings: Any) -> None:
 
     # Unfortunately we can't copy settings from edx-platform because tutor patches have
     # not been applied yet
-    settings.FORUM_MONGODB_DATABASE = "cs_comments_service"
+    settings.FORUM_MONGODB_DATABASE = getattr(
+        settings, "FORUM_MONGODB_DATABASE", "cs_comments_service"
+    )
     settings.FORUM_MONGODB_CLIENT_PARAMETERS = getattr(
         settings, "FORUM_MONGODB_CLIENT_PARAMETERS", {"host": "mongodb"}
     )
 
     # Enable forum service
-    settings.FEATURES["ENABLE_DISCUSSION_SERVICE"] = True
-    # URL prefix must match the regex in the url_config of the plugin app
-    settings.COMMENTS_SERVICE_URL = "http://localhost:8000/forum"
+    if "ENABLE_DISCUSSION_SERVICE" not in settings.FEATURES:
+        settings.FEATURES["ENABLE_DISCUSSION_SERVICE"] = True
 
-    settings.USE_TZ = True
+    # URL prefix must match the regex in the url_config of the plugin app
+    settings.COMMENTS_SERVICE_URL = getattr(
+        settings, "COMMENTS_SERVICE_URL", "http://localhost:8000/forum"
+    )
+
+    # Timezone-awareness is required for mysql fields
+    settings.USE_TZ = getattr(settings, "USE_TZ", True)


### PR DESCRIPTION
The forum app should not automatically override upstream settings. If it does, then it will have edx-platform point to the new forum v2 app even if the forum v2 waffle flag is toggled off.

This was causing issues for platforms running forum v1:

	Traceback (most recent call last):
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/connectionpool.py", line 536, in _make_request
	    response = conn.getresponse()
		       ^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/connection.py", line 507, in getresponse
	    httplib_response = super().getresponse()
			       ^^^^^^^^^^^^^^^^^^^^^
	  File "/usr/lib/python3.11/http/client.py", line 1395, in getresponse
	    response.begin()
	  File "/usr/lib/python3.11/http/client.py", line 325, in begin
	    version, status, reason = self._read_status()
				      ^^^^^^^^^^^^^^^^^^^
	  File "/usr/lib/python3.11/http/client.py", line 286, in _read_status
	    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
		       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/usr/lib/python3.11/socket.py", line 718, in readinto
	    return self._sock.recv_into(b)
		   ^^^^^^^^^^^^^^^^^^^^^^^
	TimeoutError: timed out

	The above exception was the direct cause of the following exception:

	Traceback (most recent call last):
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/requests/adapters.py", line 667, in send
	    resp = conn.urlopen(
		   ^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/connectionpool.py", line 843, in urlopen
	    retries = retries.increment(
		      ^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/util/retry.py", line 474, in increment
	    raise reraise(type(error), error, _stacktrace)
		  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/util/util.py", line 39, in reraise
	    raise value
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/connectionpool.py", line 789, in urlopen
	    response = self._make_request(
		       ^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/connectionpool.py", line 538, in _make_request
	    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/urllib3/connectionpool.py", line 369, in _raise_timeout
	    raise ReadTimeoutError(
	urllib3.exceptions.ReadTimeoutError: HTTPConnectionPool(host='localhost', port=8000): Read timed out. (read timeout=5.0)

	During handling of the above exception, another exception occurred:

	Traceback (most recent call last):
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
	    response = wrapped_callback(request, *callback_args, **callback_kwargs)
		       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/usr/lib/python3.11/contextlib.py", line 81, in inner
	    return func(*args, **kwds)
		   ^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
	    return func(mod, pin, wrapped, instance, args, kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
	    return func(*args, **kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
	    return view_func(*args, **kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/viewsets.py", line 125, in view
	    return self.dispatch(request, *args, **kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/trace_utils.py", line 336, in wrapper
	    return func(mod, pin, wrapped, instance, args, kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/django/patch.py", line 333, in wrapped
	    return func(*args, **kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
	    response = self.handle_exception(exc)
		       ^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
	    response = handler(request, *args, **kwargs)
		       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/rest_api/views.py", line 636, in list
	    return get_thread_list(
		   ^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/rest_api/api.py", line 962, in get_thread_list
	    context = get_context(course, request)
		      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/rest_api/serializers.py", line 71, in get_context
	    cc_requester = CommentClientUser.from_django_user(requester).retrieve(course_id=course.id)
			   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/models.py", line 69, in retrieve
	    self._retrieve(*args, **kwargs)
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/user.py", line 263, in _retrieve
	    response = utils.perform_request(
		       ^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/django_comment_common/comment_client/utils.py", line 66, in perform_request
	    response = requests.request(
		       ^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/requests/api.py", line 59, in request
	    return session.request(method=method, url=url, **kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/appsec/_common_module_patches.py", line 210, in wrapped_request_D8CB81E472AF98A2
	    return original_request_callable(*args, **kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
	    resp = self.send(prep, **send_kwargs)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/ddtrace/contrib/internal/requests/connection.py", line 109, in _wrap_send
	    response = func(*args, **kwargs)
		       ^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/requests/sessions.py", line 703, in send
	    r = adapter.send(request, **kwargs)
		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/requests/adapters.py", line 713, in send
	    raise ReadTimeout(e, request=request)
	requests.exceptions.ReadTimeout: HTTPConnectionPool(host='localhost', port=8000): Read timed out. (read timeout=5.0)

