### PR TITLE
fix: skip migrating read_state of deleted threads

### DIFF
--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/tests/test_management/test_commands/test_migration_commands.py
+++ b/tests/test_management/test_commands/test_migration_commands.py
@@ -436,6 +436,7 @@ def test_delete_all_courses(patched_mongodb: Database[Any]) -> None:
 def test_last_read_times_migration(patched_mongodb: Database[Any]) -> None:
     """Mock test last_read_times migration while migrating read_states of a thread."""
     comment_thread_id = ObjectId()
+    deleted_comment_thread_id = ObjectId()
     last_read_time_for_thread = timezone.now()
     patched_mongodb.users.insert_one(
         {
@@ -451,7 +452,8 @@ def test_last_read_times_migration(patched_mongodb: Database[Any]) -> None:
                 {
                     "course_id": "test_course",
                     "last_read_times": {
-                        str(comment_thread_id): last_read_time_for_thread
+                        str(comment_thread_id): last_read_time_for_thread,
+                        str(deleted_comment_thread_id): last_read_time_for_thread,
                     },
                 }
             ],


### PR DESCRIPTION
In cs_comment_service, the read_state of a thread is retained even after the thread is deleted This error is occurring during migration of read_states for old courses that has data in mongodb and has read_state saved for deleted threads.

This commit ensures that the migration process will skip any read_state associated with threads that no longer exist.
close #143

