### PR TITLE
fix: get_read_states returning wrong value of read states

### DIFF
--- a/forum/backends/mongodb/api.py
+++ b/forum/backends/mongodb/api.py
@@ -457,7 +457,17 @@ class MongoBackend(AbstractBackend):
             user = Users().find_one(
                 {"_id": user_id, "read_states.course_id": course_id}
             )
-            read_state = user["read_states"][0] if user else {}
+            if not user:
+                return {}
+
+            read_state = next(
+                (
+                    rs
+                    for rs in user.get("read_states", [])
+                    if rs.get("course_id") == course_id
+                ),
+                None,
+            )
             if read_state:
                 read_dates = read_state.get("last_read_times", {})
                 for thread in threads:


### PR DESCRIPTION
This PR fixes the get_read_states method that was only extracting the 1st course read state for users and not working for all other courses.

close #144 
