### PR TITLE
fix: delete thread throwing error

### DIFF
--- a/forum/backends/mongodb/users.py
+++ b/forum/backends/mongodb/users.py
@@ -123,7 +123,8 @@ class Users(MongoBaseModel):
         for user in list(users):
             updated_read_states = []
             for read_state in user.get("read_states", []):
-                del read_state["last_read_times"][thread_id]
+                if read_state["last_read_times"].get(thread_id):
+                    del read_state["last_read_times"][thread_id]
                 updated_read_states.append(read_state)
             self._collection.update_one(
                 {"_id": user["_id"]}, {"$set": {"read_states": updated_read_states}}


### PR DESCRIPTION
This PR fixes delete thread api throwing an error when the thread id wasn't being fetched from the users' read states.

close #147

