### PR TITLE
fix: get_user_threads api args

### DIFF
--- a/forum/api/threads.py
+++ b/forum/api/threads.py
@@ -359,6 +359,7 @@ def get_user_threads(
     user_id: Optional[str] = None,
     group_id: Optional[int] = None,
     group_ids: Optional[int] = None,
+    **kwargs: Any,
 ) -> dict[str, Any]:
     """
     Get the threads for the given thread_ids.


### PR DESCRIPTION
The get_user_threads api was not accepting additional arguments and there the discussion xblock wasn't working with the forum service. 

This PR adds args and kwargs params to the api to avoid breakage.

close #149

