### PR TITLE
fix: inline discussion compatibility issues

### DIFF
--- a/forum/serializers/contents.py
+++ b/forum/serializers/contents.py
@@ -66,7 +66,7 @@ class ContentSerializer(serializers.Serializer[dict[str, Any]]):
     updated_at = CustomDateTimeField(allow_null=True)
     at_position_list = serializers.ListField(default=[])
     user_id = serializers.CharField(source="author_id")
-    username = serializers.CharField(source="author_username")
+    username = serializers.CharField(source="author_username", allow_null=True)
     commentable_id = serializers.CharField(default="course")
     votes = VoteSummarySerializer()
     abuse_flaggers = serializers.ListField(child=serializers.CharField(), default=[])


### PR DESCRIPTION
**Description:** This PR allows username in content serializer to be null to avoid breakages with the inline discussion module in openedx.
