### PR TITLE
fix: Avoid exception when migrating read states

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="us-west-2" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-west-2" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/forum.iml
+++ b/.idea/forum.iml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="django" name="Django">
+      <configuration>
+        <option name="rootFolder" value="$MODULE_DIR$" />
+        <option name="settingsModule" value="forum/settings/test.py" />
+        <option name="manageScript" value="$MODULE_DIR$/manage.py" />
+        <option name="environment" value="&lt;map/&gt;" />
+        <option name="doNotUseTestRunner" value="false" />
+        <option name="trackFilePattern" value="migrations" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Django" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/forum/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,96 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="scoped" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="7">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+            <item index="6" class="java.lang.String" itemvalue="style" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="3.8" />
+            <item index="1" class="java.lang.String" itemvalue="3.11" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="46">
+            <item index="0" class="java.lang.String" itemvalue="aws-cdk.aws-sam" />
+            <item index="1" class="java.lang.String" itemvalue="aws-cdk.aws-lambda-nodejs" />
+            <item index="2" class="java.lang.String" itemvalue="aws-cdk.aws-certificatemanager" />
+            <item index="3" class="java.lang.String" itemvalue="aws-cdk.core" />
+            <item index="4" class="java.lang.String" itemvalue="aws-cdk.aws-ecr-assets" />
+            <item index="5" class="java.lang.String" itemvalue="aws-cdk.aws-cloudformation" />
+            <item index="6" class="java.lang.String" itemvalue="aws-cdk.aws-codeguruprofiler" />
+            <item index="7" class="java.lang.String" itemvalue="aws-cdk.aws-iam" />
+            <item index="8" class="java.lang.String" itemvalue="aws-cdk.aws-sqs" />
+            <item index="9" class="java.lang.String" itemvalue="aws-cdk.aws-ec2" />
+            <item index="10" class="java.lang.String" itemvalue="aws-cdk.aws-ecr" />
+            <item index="11" class="java.lang.String" itemvalue="aws-cdk.aws-elasticloadbalancingv2" />
+            <item index="12" class="java.lang.String" itemvalue="aws-cdk.aws-opensearchservice" />
+            <item index="13" class="java.lang.String" itemvalue="aws-cdk.aws-elasticloadbalancing" />
+            <item index="14" class="java.lang.String" itemvalue="aws-cdk.custom-resources" />
+            <item index="15" class="java.lang.String" itemvalue="aws-cdk.aws-codestarnotifications" />
+            <item index="16" class="java.lang.String" itemvalue="aws-cdk.aws-eks" />
+            <item index="17" class="java.lang.String" itemvalue="aws-cdk.aws-lambda" />
+            <item index="18" class="java.lang.String" itemvalue="aws-cdk.aws-ssm" />
+            <item index="19" class="java.lang.String" itemvalue="aws-cdk.cloud-assembly-schema" />
+            <item index="20" class="java.lang.String" itemvalue="aws-cdk.aws-cloudwatch" />
+            <item index="21" class="java.lang.String" itemvalue="aws-cdk.aws-events" />
+            <item index="22" class="java.lang.String" itemvalue="aws-cdk.aws-kms" />
+            <item index="23" class="java.lang.String" itemvalue="aws-cdk.aws-acmpca" />
+            <item index="24" class="java.lang.String" itemvalue="aws-cdk.aws-signer" />
+            <item index="25" class="java.lang.String" itemvalue="aws-cdk.aws-autoscaling" />
+            <item index="26" class="java.lang.String" itemvalue="aws-cdk.aws-s3" />
+            <item index="27" class="java.lang.String" itemvalue="aws-cdk.aws-elasticache" />
+            <item index="28" class="java.lang.String" itemvalue="aws-cdk.aws-secretsmanager" />
+            <item index="29" class="java.lang.String" itemvalue="aws-cdk.aws-applicationautoscaling" />
+            <item index="30" class="java.lang.String" itemvalue="aws-cdk.lambda-layer-awscli" />
+            <item index="31" class="java.lang.String" itemvalue="aws-cdk.aws-logs" />
+            <item index="32" class="java.lang.String" itemvalue="aws-cdk.aws-elasticsearch" />
+            <item index="33" class="java.lang.String" itemvalue="aws-cdk.cx-api" />
+            <item index="34" class="java.lang.String" itemvalue="aws-cdk.aws-sns" />
+            <item index="35" class="java.lang.String" itemvalue="aws-cdk.aws-route53" />
+            <item index="36" class="java.lang.String" itemvalue="aws-cdk.lambda-layer-node-proxy-agent" />
+            <item index="37" class="java.lang.String" itemvalue="aws-cdk.aws-autoscaling-common" />
+            <item index="38" class="java.lang.String" itemvalue="aws-cdk.region-info" />
+            <item index="39" class="java.lang.String" itemvalue="aws-cdk.aws-efs" />
+            <item index="40" class="java.lang.String" itemvalue="aws-cdk.assets" />
+            <item index="41" class="java.lang.String" itemvalue="aws-cdk.aws-s3-assets" />
+            <item index="42" class="java.lang.String" itemvalue="aws-cdk.lambda-layer-kubectl" />
+            <item index="43" class="java.lang.String" itemvalue="jsii" />
+            <item index="44" class="java.lang.String" itemvalue="attrs" />
+            <item index="45" class="java.lang.String" itemvalue="tutor" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/forum.iml" filepath="$PROJECT_DIR$/.idea/forum.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/forum/migration_helpers.py
+++ b/forum/migration_helpers.py
@@ -250,9 +250,12 @@ def migrate_read_states(db: Database[dict[str, Any]], course_id: str) -> None:
                 for thread_id, timestamp in read_state.get(
                     "last_read_times", {}
                 ).items():
-                    mongo_content = MongoContent.objects.filter(
-                        mongo_id=thread_id
-                    ).first()
+                    try:
+                        mongo_content = MongoContent.objects.filter(
+                            mongo_id=thread_id
+                        ).first()
+                    except MongoContent.DoesNotExist:
+                        continue
                     thread = mongo_content and mongo_content.content
 
                     # For older courses using cs_comment_service, the thread may be None

--- a/forum/utils.py
+++ b/forum/utils.py
@@ -1,6 +1,7 @@
 """Forum Utils."""
 
 import logging
+import unicodedata
 from datetime import datetime
 from typing import Any, Sequence
 
@@ -258,6 +259,8 @@ def get_trunc_title(title: str) -> str:
     Returns:
         str: A truncated title string with length less than 1025 characters.
     """
+    # Remove emojis from the title
+    title = ''.join(char for char in title if unicodedata.category(char)[0] != 'S')
     return title[:1024]
 
 


### PR DESCRIPTION
When a thread is deleted, a read state may be retained pointing to a non-existent thread. This may cause a `DoesNotExist` exception during migration of read
states.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
