### PR TITLE
fix: do not raise runtime errors when checking if the MySQL backend is enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,16 @@ Unreleased
 
 *
 
+0.3.2 – 2025-05-21
+******************
+
+Fixed
+=====
+
+* Do not raise runtime errors if an incorrect course ID is provided when
+  checking if the MySQL backend is enabled.
+
+
 0.3.0 – 2025-04-23
 ******************
 

--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/forum/backend.py
+++ b/forum/backend.py
@@ -13,6 +13,7 @@ def is_mysql_backend_enabled(course_id: str | None) -> bool:
     try:
         # pylint: disable=import-outside-toplevel
         from forum.toggles import ENABLE_MYSQL_BACKEND
+        from opaque_keys import InvalidKeyError
         from opaque_keys.edx.keys import CourseKey
     except ImportError:
         return True
@@ -21,7 +22,10 @@ def is_mysql_backend_enabled(course_id: str | None) -> bool:
     if isinstance(course_id, CourseKey):
         course_key = course_id  # type: ignore[unreachable]
     elif isinstance(course_id, str):
-        course_key = CourseKey.from_string(course_id)
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            pass
 
     return ENABLE_MYSQL_BACKEND.is_enabled(course_key)
 


### PR DESCRIPTION
The edx-platform incorrectly passes `str(None)` in many places when course ID is not present ([example](https://github.com/openedx/edx-platform/pull/36753)). While this change silently ignores incorrect values provided by the platform, it is better than having runtime errors in production.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings): n/a
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated: n/a
- [ ] <s>Manual testing instructions provided</s>
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
