### PR TITLE
Angonz/fix forum migration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,9 @@ Change Log
 Unreleased
 **********
 
-*
+* Fixed broken migration when the author of a comment or thread does not exist.
+* Fixed broken migration when the parent of a comment does not exist.
+* Fixed warnings for using naive datetimes.
 
 0.1.0 – 2024-11-12
 ******************

--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
This PR affects only the execution of the [forum_migrate_course_from_mongodb_to_mysql](https://github.com/openedx/forum/blob/master/forum/management/commands/forum_migrate_course_from_mongodb_to_mysql.py) manage command.

It fixes some abnormal cases that break the migration process:
- Skip a record if the author does not exist as a user.
- Skip a record if the parent message does not exist in MongoDB
- Use tz-aware dates to avoid annoying warning messages during migration.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
