### PR TITLE
fix: refactor get_user_subscriptions to unpack query_params

### DIFF
--- a/forum/api/subscriptions.py
+++ b/forum/api/subscriptions.py
@@ -13,6 +13,7 @@ from forum.pagination import ForumPagination
 from forum.serializers.subscriptions import SubscriptionSerializer
 from forum.serializers.thread import ThreadSerializer
 from forum.utils import ForumV2RequestError
+from forum.constants import FORUM_DEFAULT_PAGE, FORUM_DEFAULT_PER_PAGE
 
 
 def validate_user_and_thread(
@@ -65,15 +66,44 @@ def delete_subscription(
 
 
 def get_user_subscriptions(
-    user_id: str, course_id: str, query_params: dict[str, Any]
+    user_id: str,
+    course_id: str,
+    author_id: Optional[str] = None,
+    thread_type: Optional[str] = None,
+    flagged: Optional[bool] = False,
+    unread: Optional[bool] = False,
+    unanswered: Optional[bool] = False,
+    unresponded: Optional[bool] = False,
+    count_flagged: Optional[bool] = False,
+    sort_key: Optional[str] = "date",
+    page: Optional[int] = FORUM_DEFAULT_PAGE,
+    per_page: Optional[int] = FORUM_DEFAULT_PER_PAGE,
+    group_id: Optional[str] = None,
+    group_ids: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Get a user's subscriptions.
     """
     backend = get_backend(course_id)()
-    backend.validate_params(query_params, user_id)
+    params = {
+        "course_id": course_id,
+        "author_id": author_id,
+        "thread_type": thread_type,
+        "flagged": flagged,
+        "unread": unread,
+        "unanswered": unanswered,
+        "unresponded": unresponded,
+        "count_flagged": count_flagged,
+        "sort_key": sort_key,
+        "page": int(page) if page else None,
+        "per_page": int(per_page) if per_page else None,
+        "user_id": user_id,
+        "group_id": group_id,
+        "group_ids": group_ids,
+    }
+    params = {k: v for k, v in params.items() if v is not None}
     thread_ids = backend.find_subscribed_threads(user_id, course_id)
-    threads = backend.get_threads(query_params, user_id, ThreadSerializer, thread_ids)
+    threads = backend.get_threads(params, user_id, ThreadSerializer, thread_ids)
     return threads
 
 

--- a/forum/utils.py
+++ b/forum/utils.py
@@ -244,8 +244,7 @@ def get_sort_criteria(sort_key: str) -> Sequence[tuple[str, int]]:
         if sort_key not in ["created_at", "last_activity_at"]:
             sort_criteria.append(("created_at", -1))
         return sort_criteria
-    else:
-        return []
+    return []
 
 
 def get_trunc_title(title: str) -> str:

--- a/forum/views/subscriptions.py
+++ b/forum/views/subscriptions.py
@@ -1,5 +1,7 @@
 """Subscriptions API Views."""
 
+from typing import Any
+
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
@@ -91,10 +93,13 @@ class UserSubscriptionAPIView(APIView):
         Raises:
             HTTP_400_BAD_REQUEST: If the user does not exist.
         """
-        params = request.GET.dict()
+        params: dict[str, Any] = request.GET.dict()
+        course_id = params.pop("course_id")
         try:
             serilized_data = get_user_subscriptions(
-                user_id, params["course_id"], params
+                user_id,
+                course_id,
+                **params,
             )
         except ForumV2RequestError as e:
             return Response(data={"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
The PR refactors the get_user_subscriptions function to use positional and optional arguments instead of a general query_params dictionary. This refactoring makes this function work similarly to other functions, such as get_user_threads. 