### PR TITLE
fix: get_user_course_stats returns 500

### DIFF
--- a/forum/api/users.py
+++ b/forum/api/users.py
@@ -296,7 +296,7 @@ def _get_stats_for_usernames(
     for user in users:
         if user["username"] not in usernames:
             continue
-        course_stats = user["course_stats"]
+        course_stats = user.get("course_stats")
         if course_stats:
             for course_stat in course_stats:
                 if course_stat["course_id"] == course_id:


### PR DESCRIPTION
This PR fixes get_user_course_stats api where searched user didn't have a course_stats object associated and code was expecting it to exist in all cases.

close #217 
