### PR TITLE
fix: Sort threads issue after pin/unpin

### DIFF
--- a/forum/backends/mongodb/api.py
+++ b/forum/backends/mongodb/api.py
@@ -346,7 +346,9 @@ class MongoBackend(AbstractBackend):
             thread_id (str): The ID of the thread to pin/unpin.
             action (str): The action to perform ("pin" or "unpin").
         """
-        CommentThread().update(thread_id, pinned=action == "pin")
+        CommentThread().update(
+            thread_id, pinned=action == "pin", skip_timestamp_update=True
+        )
 
     @classmethod
     def get_pinned_unpinned_thread_serialized_data(

--- a/forum/backends/mongodb/threads.py
+++ b/forum/backends/mongodb/threads.py
@@ -204,6 +204,7 @@ class CommentThread(BaseContents):
         close_reason_code: Optional[str] = None,
         closed_by_id: Optional[str] = None,
         group_id: Optional[int] = None,
+        skip_timestamp_update: bool = False,
     ) -> int:
         """
         Updates a thread document in the database.
@@ -229,6 +230,7 @@ class CommentThread(BaseContents):
             pinned: Whether the thread is pinned.
             comments_count: The number of comments on the thread.
             endorsed: Whether the thread is endorsed.
+            skip_timestamp_update: Whether to skip updating the timestamp (default: False).
 
         Returns:
             int: The number of documents modified.
@@ -277,8 +279,9 @@ class CommentThread(BaseContents):
             )
             update_data["edit_history"] = edit_history
 
-        date = datetime.now()
-        update_data["updated_at"] = date
+        if not skip_timestamp_update:
+            date = datetime.now()
+            update_data["updated_at"] = date
         result = self._collection.update_one(
             {"_id": ObjectId(thread_id)},
             {"$set": update_data},

--- a/forum/backends/mysql/api.py
+++ b/forum/backends/mysql/api.py
@@ -329,7 +329,7 @@ class MySQLBackend(AbstractBackend):
         except ObjectDoesNotExist as exc:
             raise ValueError("Thread doesn't exist") from exc
         comment_thread.pinned = action == "pin"
-        comment_thread.save()
+        comment_thread.save(update_fields=["pinned"])
 
     @classmethod
     def get_pinned_unpinned_thread_serialized_data(


### PR DESCRIPTION
This PR fixes both backends to not modify last_activity_at when pinning/unpinning threads

close: #223 