### PR TITLE
fix: Read status doesn't update after adding a new comment

### DIFF
--- a/forum/backends/mysql/api.py
+++ b/forum/backends/mysql/api.py
@@ -1501,6 +1501,12 @@ class MySQLBackend(AbstractBackend):
         )
         new_comment.sort_key = new_comment.get_sort_key()
         new_comment.save()
+
+        # Update thread's last activity timestamp to mark it as having new activity
+        if comment_thread:
+            comment_thread.last_activity_at = timezone.now()
+            comment_thread.save(update_fields=["last_activity_at"])
+
         if data.get("parent_id"):
             cls.update_child_count_in_parent_comment(data["parent_id"], 1)
             cls.update_stats_for_course(data["author_id"], data["course_id"], replies=1)


### PR DESCRIPTION
This PR fixes the mysql api for adding a new comment where the thread wasn't getting unread due to last_activity_at not being updated 

close #219
