### PR TITLE
fix: Retired author username not being fetched

### DIFF
--- a/forum/backends/mysql/models.py
+++ b/forum/backends/mysql/models.py
@@ -184,6 +184,11 @@ class Content(models.Model):
             votes["count"] = votes["count"]
         return votes
 
+    @property
+    def author_username(self) -> str:
+        """Return the username of the content author."""
+        return self.author.username
+
     def to_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the content."""
         raise NotImplementedError


### PR DESCRIPTION
This PR fixes the Content Serializer class not being able to fetch username of a retired author by adding a author_username property to the Content MySQL model.


