### PR TITLE
feat: Add backward compatibility for retrieve_all comments

### DIFF
--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"

--- a/forum/api/__init__.py
+++ b/forum/api/__init__.py
@@ -9,6 +9,7 @@ from .comments import (
     delete_comment,
     get_course_id_by_comment,
     get_parent_comment,
+    get_user_comments,
     update_comment,
 )
 from .flags import (
@@ -68,6 +69,7 @@ __all__ = [
     "get_thread_subscriptions",
     "get_user",
     "get_user_active_threads",
+    "get_user_comments",
     "get_user_course_stats",
     "get_user_subscriptions",
     "get_user_threads",


### PR DESCRIPTION
This PR adds get_user_comments api that retrieves all of the user comments as it was also supported in the cs_comments_service backend.

