### PR TITLE
build: Don't branch or tag this in the named release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,6 @@ metadata:
   name: "forum"
   description: "openedx forum app"
   annotations:
-    openedx.org/release: "master"
     openedx.org/arch-interest-groups: ""
 spec:
   owner: "group:wg-maintainers-forums"


### PR DESCRIPTION
We only branch and tag top-level backend services, frontend apps, and non-default Open edX plugins.
This, on the other hand, is a package that gets installed into edx-platform. We shouldn't tag it, because its `release/ulmo` branch is not guaranteed to line up with the openedx-forum version installed by the `release/ulmo` branch of edx-platform.

After merging, we should delete the `release/ulmo` branch.

@ormsbee , @farhaanbukhsh 