### PR TITLE
feat: Optimize MySQL backend APIs to improve performance

### DIFF
--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.3.9"
+__version__ = "0.4.0"


### PR DESCRIPTION
This commit introduces query optimizations to reduce database queries and improve response times:

- Fixed N+1 queries in threads_presentor, get_paginated_user_stats, and other methods using select_related/prefetch_related
- Optimized get_read_states to prefetch data in bulk instead of individual queries
- Optimized get_abuse_flagged_count and get_endorsed with bulk aggregations
- Removed duplicate annotations in handle_threads_query
- Added query optimizations across prepare_thread, validate_thread_and_user, and other methods

Performance impact: Reduced queries from O(n) to O(1)/O(k), eliminated N+1 patterns, improved bulk operations. All changes maintain backward compatibility.
