### PR TITLE
chore: drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.12']
         toxenv: [py, quality, django42, django52, e2e, package]
 
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install Dependencies
         run: pip install setuptools wheel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,20 @@ Unreleased
 
 * Add support for Typesense as the search backend.
 
+[0.4.0] – 2026-03-12
+*********************
+
+Breaking Changes
+----------------
+
+* Drop Python 3.11 support; Python 3.12 is now required.
+* Upgrade typesense-python from 1.x to 2.0. This release requires
+  **Typesense Server >= v30.0** (previously >= v28.0). See the
+  `typesense-python compatibility table
+  <https://github.com/typesense/typesense-python#compatibility>`_
+  for details. If you are running an older Typesense server you must
+  upgrade it before deploying this version of openedx-forum.
+
 0.3.4 – 2025-08-13
 ******************
 

--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.4.0"
+__version__ = "1.0.0"

--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "1.0.0"
+__version__ = "0.4.0"

--- a/forum/migration_helpers.py
+++ b/forum/migration_helpers.py
@@ -25,7 +25,6 @@ from forum.models import (
 )
 from forum.utils import make_aware, get_trunc_title
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/forum/search/typesense.py
+++ b/forum/search/typesense.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.paginator import Paginator
 
-from typesense.client import Client
+from typesense import Client
 from typesense.types.collection import CollectionCreateSchema
 from typesense.types.document import DocumentSchema, SearchParameters
 from typesense.exceptions import ObjectNotFound

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,27 +8,31 @@ amqp==5.3.1
     # via kombu
 annotated-types==0.7.0
     # via pydantic
-asgiref==3.9.1
+anyio==4.12.1
+    # via httpx
+asgiref==3.11.1
     # via django
-attrs==25.3.0
+attrs==25.4.0
     # via openedx-events
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.3
     # via -r requirements/base.in
-billiard==4.2.1
+billiard==4.2.4
     # via celery
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via meilisearch
-celery==5.5.3
+celery==5.6.2
     # via event-tracking
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via pynacl
-charset-normalizer==3.4.3
+charset-normalizer==3.4.5
     # via requests
-click==8.2.1
+click==8.3.1
     # via
     #   celery
     #   click-didyoumean
@@ -42,11 +46,11 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via edx-toggles
-django==4.2.23
+django==5.2.12
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-crum
     #   django-waffle
@@ -66,20 +70,20 @@ django-waffle==5.0.0
     #   edx-toggles
 djangorestframework==3.16.1
     # via -r requirements/base.in
-dnspython==2.7.0
+dnspython==2.8.0
     # via pymongo
 edx-ccx-keys==2.0.2
     # via openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   edx-toggles
     #   event-tracking
     #   openedx-events
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   edx-ccx-keys
     #   openedx-events
-edx-search==4.1.3
+edx-search==4.4.0
     # via -r requirements/base.in
 edx-toggles==5.4.1
     # via
@@ -87,90 +91,102 @@ edx-toggles==5.4.1
     #   event-tracking
 elasticsearch==7.13.4
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   edx-search
 event-tracking==3.3.0
     # via edx-search
-fastavro==1.12.0
+fastavro==1.12.1
     # via openedx-events
-idna==3.10
-    # via requests
+h11==0.16.0
+    # via httpcore
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via typesense
+idna==3.11
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 jinja2==3.1.6
     # via code-annotations
-kombu==5.5.4
+kombu==5.6.2
     # via celery
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
-meilisearch==0.37.0
+meilisearch==0.40.0
     # via edx-search
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via -r requirements/base.in
 openedx-atlas==0.7.0
     # via -r requirements/base.in
 openedx-events==10.5.0
     # via event-tracking
-packaging==25.0
+packaging==26.0
     # via kombu
 prompt-toolkit==3.0.52
     # via click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via pydantic
-pymongo==4.14.1
+pymongo==4.16.0
     # via
     #   -r requirements/base.in
     #   edx-opaque-keys
     #   event-tracking
-pynacl==1.5.0
+pynacl==1.6.2
     # via edx-django-utils
 python-dateutil==2.9.0.post0
     # via celery
 python-slugify==8.0.4
     # via code-annotations
-pytz==2025.2
+pytz==2026.1.post1
     # via event-tracking
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via code-annotations
 requests==2.32.5
     # via
     #   -r requirements/base.in
     #   meilisearch
-    #   typesense
 six==1.17.0
     # via
     #   edx-ccx-keys
     #   event-tracking
     #   python-dateutil
-soupsieve==2.8
+soupsieve==2.8.3
     # via beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.5.0
+stevedore==5.7.0
     # via
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typesense==1.1.1
+typesense==2.0.0
     # via -r requirements/base.in
 typing-extensions==4.15.0
     # via
+    #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
+    #   typesense
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via kombu
+tzlocal==5.3.1
+    # via celery
 urllib3==1.26.20
     # via
     #   elasticsearch
@@ -180,7 +196,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via prompt-toolkit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,60 +12,62 @@ annotated-types==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pydantic
-asgiref==3.9.1
+anyio==4.12.1
+    # via
+    #   -r requirements/quality.txt
+    #   httpx
+asgiref==3.11.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.11
+astroid==4.0.4
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/quality.txt
     #   openedx-events
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.3
     # via -r requirements/quality.txt
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/quality.txt
     #   celery
-black==25.1.0
+black==26.3.0
     # via -r requirements/ci.in
-build==1.3.0
+build==1.4.0
     # via -r requirements/quality.txt
-cachetools==6.2.0
+cachetools==7.0.3
     # via
     #   -r requirements/quality.txt
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/quality.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.2
     # via
     #   -r requirements/quality.txt
     #   event-tracking
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   -r requirements/quality.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/quality.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.5
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/quality.txt
     #   black
@@ -93,7 +95,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/quality.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -102,15 +104,15 @@ colorama==0.4.6
     # via
     #   -r requirements/quality.txt
     #   tox
-coverage[toml]==7.10.5
+coverage[toml]==7.13.4
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via
     #   -r requirements/quality.txt
     #   secretstorage
-dill==0.4.0
+dill==0.4.1
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -118,9 +120,9 @@ distlib==0.4.0
     # via
     #   -r requirements/quality.txt
     #   virtualenv
-django==4.2.23
+django==5.2.12
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   django-crum
     #   django-stubs
@@ -137,11 +139,11 @@ django-crum==0.7.9
     #   -r requirements/quality.txt
     #   edx-django-utils
     #   edx-toggles
-django-stubs==5.2.2
+django-stubs==5.2.9
     # via
     #   -r requirements/quality.txt
     #   djangorestframework-stubs
-django-stubs-ext==5.2.2
+django-stubs-ext==5.2.9
     # via
     #   -r requirements/quality.txt
     #   django-stubs
@@ -152,13 +154,13 @@ django-waffle==5.0.0
     #   edx-toggles
 djangorestframework==3.16.1
     # via -r requirements/quality.txt
-djangorestframework-stubs==3.16.2
+djangorestframework-stubs==3.16.8
     # via -r requirements/quality.txt
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/quality.txt
     #   pymongo
-docutils==0.22
+docutils==0.22.4
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -166,7 +168,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/quality.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/quality.txt
     #   edx-toggles
@@ -174,12 +176,12 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/quality.txt
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   -r requirements/quality.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-search==4.1.3
+edx-search==4.4.0
     # via -r requirements/quality.txt
 edx-toggles==5.4.1
     # via
@@ -188,37 +190,52 @@ edx-toggles==5.4.1
     #   event-tracking
 elasticsearch==7.13.4
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   edx-search
 event-tracking==3.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-search
-faker==37.6.0
+faker==40.8.0
     # via -r requirements/quality.txt
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/quality.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.25.0
     # via
     #   -r requirements/quality.txt
+    #   python-discovery
     #   tox
     #   virtualenv
+h11==0.16.0
+    # via
+    #   -r requirements/quality.txt
+    #   httpcore
+httpcore==1.0.9
+    # via
+    #   -r requirements/quality.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -r requirements/quality.txt
+    #   typesense
 id==1.5.0
     # via
     #   -r requirements/quality.txt
     #   twine
-idna==3.10
+idna==3.11
     # via
     #   -r requirements/quality.txt
+    #   anyio
+    #   httpx
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==6.0.1
+isort==8.0.1
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -226,11 +243,11 @@ jaraco-classes==3.4.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.3.0
+jaraco-functools==4.4.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -243,19 +260,23 @@ jinja2==3.1.6
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-keyring==25.6.0
+keyring==25.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/quality.txt
     #   celery
+librt==0.8.1
+    # via
+    #   -r requirements/quality.txt
+    #   mypy
 markdown-it-py==4.0.0
     # via
     #   -r requirements/quality.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/quality.txt
     #   jinja2
@@ -267,27 +288,27 @@ mdurl==0.1.2
     # via
     #   -r requirements/quality.txt
     #   markdown-it-py
-meilisearch==0.37.0
+meilisearch==0.40.0
     # via
     #   -r requirements/quality.txt
     #   edx-search
 mongomock==4.3.0
     # via -r requirements/quality.txt
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.17.1
+mypy==1.19.1
     # via -r requirements/quality.txt
 mypy-extensions==1.1.0
     # via
     #   -r requirements/quality.txt
     #   black
     #   mypy
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via -r requirements/quality.txt
-nh3==0.3.0
+nh3==0.3.3
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -297,7 +318,7 @@ openedx-events==10.5.0
     # via
     #   -r requirements/quality.txt
     #   event-tracking
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/quality.txt
     #   black
@@ -308,16 +329,17 @@ packaging==25.0
     #   pytest
     #   tox
     #   twine
-pathspec==0.12.1
+pathspec==1.0.4
     # via
     #   -r requirements/quality.txt
     #   black
     #   mypy
-platformdirs==4.4.0
+platformdirs==4.9.4
     # via
     #   -r requirements/quality.txt
     #   black
     #   pylint
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -330,21 +352,21 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/quality.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
 pycodestyle==2.14.0
     # via -r requirements/quality.txt
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/quality.txt
     #   cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via
     #   -r requirements/quality.txt
     #   camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via
     #   -r requirements/quality.txt
     #   pydantic
@@ -356,7 +378,7 @@ pygments==2.19.2
     #   pytest
     #   readme-renderer
     #   rich
-pylint==3.3.8
+pylint==4.0.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -367,7 +389,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -376,16 +398,16 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.1
+pymongo==4.16.0
     # via
     #   -r requirements/quality.txt
     #   edx-opaque-keys
     #   event-tracking
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/quality.txt
     #   tox
@@ -393,29 +415,35 @@ pyproject-hooks==1.2.0
     # via
     #   -r requirements/quality.txt
     #   build
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/quality.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/quality.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/quality.txt
     #   celery
+python-discovery==1.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   virtualenv
 python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2025.2
+pytokens==0.4.1
+    # via black
+pytz==2026.1.post1
     # via
     #   -r requirements/quality.txt
     #   event-tracking
     #   mongomock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -426,12 +454,10 @@ readme-renderer==44.0
 requests==2.32.5
     # via
     #   -r requirements/quality.txt
-    #   djangorestframework-stubs
     #   id
     #   meilisearch
     #   requests-toolbelt
     #   twine
-    #   typesense
 requests-toolbelt==1.0.0
     # via
     #   -r requirements/quality.txt
@@ -440,11 +466,11 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==14.1.0
+rich==14.3.3
     # via
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.3
+secretstorage==3.5.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -463,15 +489,15 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-soupsieve==2.8
+soupsieve==2.8.3
     # via
     #   -r requirements/quality.txt
     #   beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==5.5.0
+stevedore==5.7.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -481,38 +507,45 @@ text-unidecode==1.3
     # via
     #   -r requirements/quality.txt
     #   python-slugify
-tomlkit==0.13.3
+tomli-w==1.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   tox
+tomlkit==0.14.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.28.4
+tox==4.49.0
     # via -r requirements/quality.txt
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/quality.txt
 types-beautifulsoup4==4.12.0.20250516
     # via -r requirements/quality.txt
-types-html5lib==1.1.11.20250809
+types-html5lib==1.1.11.20251117
     # via
     #   -r requirements/quality.txt
     #   types-beautifulsoup4
-types-pyyaml==6.0.12.20250822
+types-pyyaml==6.0.12.20250915
     # via
     #   -r requirements/quality.txt
     #   django-stubs
     #   djangorestframework-stubs
 types-requests==2.31.0.6
-    # via
-    #   -r requirements/quality.txt
-    #   djangorestframework-stubs
+    # via -r requirements/quality.txt
 types-urllib3==1.26.25.14
     # via
     #   -r requirements/quality.txt
     #   types-requests
-typesense==1.1.1
+types-webencodings==0.5.0.20251108
+    # via
+    #   -r requirements/quality.txt
+    #   types-html5lib
+typesense==2.0.0
     # via -r requirements/quality.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/quality.txt
+    #   anyio
     #   beautifulsoup4
     #   django-stubs
     #   django-stubs-ext
@@ -521,16 +554,20 @@ typing-extensions==4.15.0
     #   mypy
     #   pydantic
     #   pydantic-core
+    #   typesense
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via
     #   -r requirements/quality.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/quality.txt
-    #   faker
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/quality.txt
+    #   celery
 urllib3==1.26.20
     # via
     #   -r requirements/quality.txt
@@ -543,11 +580,11 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.1.0
     # via
     #   -r requirements/quality.txt
     #   tox
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via
     #   -r requirements/quality.txt
     #   prompt-toolkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,78 +14,81 @@ annotated-types==0.7.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pydantic
-asgiref==3.9.1
+anyio==4.12.1
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   httpx
+asgiref==3.11.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.11
+astroid==4.0.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   openedx-events
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   celery
-black==25.1.0
+black==26.3.0
     # via -r requirements/ci.txt
-build==1.3.0
+build==1.4.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   pip-tools
-cachetools==6.2.0
+cachetools==7.0.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   event-tracking
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
-    # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-    #   diff-cover
-    #   tox
-charset-normalizer==3.4.3
+chardet==7.0.1
+    # via diff-cover
+charset-normalizer==3.4.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -120,7 +123,7 @@ click-repl==0.3.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -131,19 +134,19 @@ colorama==0.4.6
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   tox
-coverage[toml]==7.10.5
+coverage[toml]==7.13.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   secretstorage
-diff-cover==9.6.0
+diff-cover==10.2.0
     # via -r requirements/dev.in
-dill==0.4.0
+dill==0.4.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -153,9 +156,9 @@ distlib==0.4.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   virtualenv
-django==4.2.23
+django==5.2.12
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   django-crum
@@ -175,12 +178,12 @@ django-crum==0.7.9
     #   -r requirements/quality.txt
     #   edx-django-utils
     #   edx-toggles
-django-stubs==5.2.2
+django-stubs==5.2.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   djangorestframework-stubs
-django-stubs-ext==5.2.2
+django-stubs-ext==5.2.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -195,16 +198,16 @@ djangorestframework==3.16.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-djangorestframework-stubs==3.16.2
+djangorestframework-stubs==3.16.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pymongo
-docutils==0.22
+docutils==0.22.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -214,7 +217,7 @@ edx-ccx-keys==2.0.2
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -227,13 +230,13 @@ edx-lint==5.6.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-search==4.1.3
+edx-search==4.4.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -245,7 +248,7 @@ edx-toggles==5.4.1
     #   event-tracking
 elasticsearch==7.13.4
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-search
@@ -254,37 +257,55 @@ event-tracking==3.3.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-search
-faker==37.6.0
+faker==40.8.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.25.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
+    #   python-discovery
     #   tox
     #   virtualenv
+h11==0.16.0
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   httpcore
+httpcore==1.0.9
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   typesense
 id==1.5.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   twine
-idna==3.10
+idna==3.11
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
+    #   anyio
+    #   httpx
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest
-isort==6.0.1
+isort==8.0.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -294,12 +315,12 @@ jaraco-classes==3.4.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.3.0
+jaraco-functools==4.4.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -316,28 +337,33 @@ jinja2==3.1.6
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-keyring==25.6.0
+keyring==25.7.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   twine
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   celery
-lxml[html-clean]==6.0.1
+librt==0.8.1
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   mypy
+lxml[html-clean]==6.0.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.4
     # via lxml
 markdown-it-py==4.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -352,7 +378,7 @@ mdurl==0.1.2
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   markdown-it-py
-meilisearch==0.37.0
+meilisearch==0.40.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -361,13 +387,13 @@ mongomock==4.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.17.1
+mypy==1.19.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -377,11 +403,11 @@ mypy-extensions==1.1.0
     #   -r requirements/quality.txt
     #   black
     #   mypy
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-nh3==0.3.0
+nh3==0.3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -395,7 +421,7 @@ openedx-events==10.5.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   event-tracking
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -408,22 +434,24 @@ packaging==25.0
     #   pytest
     #   tox
     #   twine
+    #   wheel
 path==16.16.0
     # via edx-i18n-tools
-pathspec==0.12.1
+pathspec==1.0.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   black
     #   mypy
-pip-tools==7.5.0
+pip-tools==7.5.3
     # via -r requirements/pip-tools.txt
-platformdirs==4.4.0
+platformdirs==4.9.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   black
     #   pylint
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -441,7 +469,7 @@ prompt-toolkit==3.0.52
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -450,17 +478,17 @@ pycodestyle==2.14.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -477,7 +505,7 @@ pygments==2.19.2
     #   pytest
     #   readme-renderer
     #   rich
-pylint==3.3.8
+pylint==4.0.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -490,7 +518,7 @@ pylint-celery==0.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -501,18 +529,18 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.1
+pymongo==4.16.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-opaque-keys
     #   event-tracking
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-django-utils
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -524,17 +552,17 @@ pyproject-hooks==1.2.0
     #   -r requirements/quality.txt
     #   build
     #   pip-tools
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -543,18 +571,27 @@ python-dateutil==2.9.0.post0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   celery
+python-discovery==1.1.0
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   virtualenv
 python-slugify==8.0.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2025.2
+pytokens==0.4.1
+    # via
+    #   -r requirements/ci.txt
+    #   black
+pytz==2026.1.post1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   event-tracking
     #   mongomock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -569,12 +606,10 @@ requests==2.32.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   djangorestframework-stubs
     #   id
     #   meilisearch
     #   requests-toolbelt
     #   twine
-    #   typesense
 requests-toolbelt==1.0.0
     # via
     #   -r requirements/ci.txt
@@ -585,12 +620,12 @@ rfc3986==2.0.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   twine
-rich==14.1.0
+rich==14.3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.3
+secretstorage==3.5.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -613,17 +648,17 @@ snowballstemmer==3.0.1
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pydocstyle
-soupsieve==2.8
+soupsieve==2.8.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   django
-stevedore==5.5.0
+stevedore==5.7.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -635,16 +670,21 @@ text-unidecode==1.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   python-slugify
-tomlkit==0.13.3
+tomli-w==1.2.0
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   tox
+tomlkit==0.14.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
-tox==4.28.4
+tox==4.49.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-twine==6.1.0
+twine==6.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -652,12 +692,12 @@ types-beautifulsoup4==4.12.0.20250516
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-types-html5lib==1.1.11.20250809
+types-html5lib==1.1.11.20251117
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   types-beautifulsoup4
-types-pyyaml==6.0.12.20250822
+types-pyyaml==6.0.12.20250915
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -667,13 +707,17 @@ types-requests==2.31.0.6
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   djangorestframework-stubs
 types-urllib3==1.26.25.14
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   types-requests
-typesense==1.1.1
+types-webencodings==0.5.0.20251108
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   types-html5lib
+typesense==2.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -681,6 +725,7 @@ typing-extensions==4.15.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
+    #   anyio
     #   beautifulsoup4
     #   django-stubs
     #   django-stubs-ext
@@ -689,18 +734,23 @@ typing-extensions==4.15.0
     #   mypy
     #   pydantic
     #   pydantic-core
+    #   typesense
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   faker
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   celery
 urllib3==1.26.20
     # via
     #   -r requirements/ci.txt
@@ -715,17 +765,17 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   tox
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   prompt-toolkit
-wheel==0.45.1
+wheel==0.46.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,9 @@
 #
 #    make upgrade
 #
-alabaster==0.7.16
+accessible-pygments==0.0.5
+    # via pydata-sphinx-theme
+alabaster==1.0.0
     # via sphinx
 amqp==5.3.1
     # via
@@ -14,59 +16,61 @@ annotated-types==0.7.0
     # via
     #   -r requirements/test.txt
     #   pydantic
-asgiref==3.9.1
+anyio==4.12.1
+    # via
+    #   -r requirements/test.txt
+    #   httpx
+asgiref==3.11.1
     # via
     #   -r requirements/test.txt
     #   django
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-babel==2.17.0
+babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.3
     # via
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-build==1.3.0
+build==1.4.0
     # via -r requirements/test.txt
-cachetools==6.2.0
+cachetools==7.0.3
     # via
     #   -r requirements/test.txt
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/test.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.2
     # via
     #   -r requirements/test.txt
     #   event-tracking
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   -r requirements/test.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
-    # via
-    #   -r requirements/test.txt
-    #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.5
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -87,7 +91,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -95,11 +99,11 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coverage[toml]==7.10.5
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via
     #   -r requirements/test.txt
     #   secretstorage
@@ -107,9 +111,9 @@ distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==4.2.23
+django==5.2.12
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-waffle
@@ -131,13 +135,13 @@ django-waffle==5.0.0
     #   edx-toggles
 djangorestframework==3.16.1
     # via -r requirements/test.txt
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/test.txt
     #   pymongo
 doc8==0.11.2
     # via -r requirements/doc.in
-docutils==0.22
+docutils==0.22.4
     # via
     #   -r requirements/test.txt
     #   doc8
@@ -149,18 +153,18 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-toggles
     #   event-tracking
     #   openedx-events
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-search==4.1.3
+edx-search==4.4.0
     # via -r requirements/test.txt
 edx-toggles==5.4.1
     # via
@@ -169,35 +173,50 @@ edx-toggles==5.4.1
     #   event-tracking
 elasticsearch==7.13.4
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-search
 event-tracking==3.3.0
     # via
     #   -r requirements/test.txt
     #   edx-search
-faker==37.6.0
+faker==40.8.0
     # via -r requirements/test.txt
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.25.0
     # via
     #   -r requirements/test.txt
+    #   python-discovery
     #   tox
     #   virtualenv
+h11==0.16.0
+    # via
+    #   -r requirements/test.txt
+    #   httpcore
+httpcore==1.0.9
+    # via
+    #   -r requirements/test.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -r requirements/test.txt
+    #   typesense
 id==1.5.0
     # via
     #   -r requirements/test.txt
     #   twine
-idna==3.10
+idna==3.11
     # via
     #   -r requirements/test.txt
+    #   anyio
+    #   httpx
     #   requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -205,11 +224,11 @@ jaraco-classes==3.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jaraco-functools==4.3.0
+jaraco-functools==4.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
@@ -223,11 +242,11 @@ jinja2==3.1.6
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-keyring==25.6.0
+keyring==25.7.0
     # via
     #   -r requirements/test.txt
     #   twine
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/test.txt
     #   celery
@@ -235,7 +254,7 @@ markdown-it-py==4.0.0
     # via
     #   -r requirements/test.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -243,20 +262,20 @@ mdurl==0.1.2
     # via
     #   -r requirements/test.txt
     #   markdown-it-py
-meilisearch==0.37.0
+meilisearch==0.40.0
     # via
     #   -r requirements/test.txt
     #   edx-search
 mongomock==4.3.0
     # via -r requirements/test.txt
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/test.txt
     #   jaraco-classes
     #   jaraco-functools
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via -r requirements/test.txt
-nh3==0.3.0
+nh3==0.3.3
     # via
     #   -r requirements/test.txt
     #   readme-renderer
@@ -266,20 +285,22 @@ openedx-events==10.5.0
     # via
     #   -r requirements/test.txt
     #   event-tracking
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/test.txt
     #   build
     #   kombu
     #   mongomock
+    #   pydata-sphinx-theme
     #   pyproject-api
     #   pytest
     #   sphinx
     #   tox
     #   twine
-platformdirs==4.4.0
+platformdirs==4.9.4
     # via
     #   -r requirements/test.txt
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -292,42 +313,44 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via
     #   -r requirements/test.txt
     #   camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via
     #   -r requirements/test.txt
     #   pydantic
-pydata-sphinx-theme==0.8.0
+pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.2
     # via
     #   -r requirements/test.txt
+    #   accessible-pygments
     #   doc8
+    #   pydata-sphinx-theme
     #   pytest
     #   readme-renderer
     #   rich
     #   sphinx
-pymongo==4.14.1
+pymongo==4.16.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
     #   event-tracking
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -335,33 +358,36 @@ pyproject-hooks==1.2.0
     # via
     #   -r requirements/test.txt
     #   build
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/test.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   celery
+python-discovery==1.1.0
+    # via
+    #   -r requirements/test.txt
+    #   virtualenv
 python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   -r requirements/test.txt
     #   event-tracking
     #   mongomock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-    #   sphinx-book-theme
 readme-renderer==44.0
     # via
     #   -r requirements/test.txt
@@ -374,22 +400,23 @@ requests==2.32.5
     #   requests-toolbelt
     #   sphinx
     #   twine
-    #   typesense
 requests-toolbelt==1.0.0
     # via
     #   -r requirements/test.txt
     #   twine
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via
     #   -r requirements/test.txt
     #   twine
-rich==14.1.0
+rich==14.3.3
     # via
     #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.3
+roman-numerals==4.1.0
+    # via sphinx
+secretstorage==3.5.0
     # via
     #   -r requirements/test.txt
     #   keyring
@@ -405,16 +432,16 @@ six==1.17.0
     #   python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.8
+soupsieve==2.8.3
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==3.5.3
+sphinx==9.1.0
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==0.3.3
+sphinx-book-theme==1.1.4
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -428,11 +455,11 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.5.0
+stevedore==5.7.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -443,29 +470,39 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tox==4.28.4
+tomli-w==1.2.0
+    # via
+    #   -r requirements/test.txt
+    #   tox
+tox==4.49.0
     # via -r requirements/test.txt
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/test.txt
-typesense==1.1.1
+typesense==2.0.0
     # via -r requirements/test.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
+    #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
+    #   pydata-sphinx-theme
+    #   typesense
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via
     #   -r requirements/test.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/test.txt
-    #   faker
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
 urllib3==1.26.20
     # via
     #   -r requirements/test.txt
@@ -478,11 +515,11 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.1.0
     # via
     #   -r requirements/test.txt
     #   tox
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,19 +4,21 @@
 #
 #    make upgrade
 #
-build==1.3.0
+build==1.4.0
     # via pip-tools
-click==8.2.1
+click==8.3.1
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.5.0
+packaging==26.0
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+packaging==26.0
+    # via wheel
+wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/pip.in
-setuptools==80.9.0
+pip==26.0.1
+    # via -r requirements/pip.in
+setuptools==82.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,57 +12,59 @@ annotated-types==0.7.0
     # via
     #   -r requirements/test.txt
     #   pydantic
-asgiref==3.9.1
+anyio==4.12.1
+    # via
+    #   -r requirements/test.txt
+    #   httpx
+asgiref==3.11.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.11
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.3
     # via -r requirements/test.txt
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-build==1.3.0
+build==1.4.0
     # via -r requirements/test.txt
-cachetools==6.2.0
+cachetools==7.0.3
     # via
     #   -r requirements/test.txt
     #   tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/test.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.2
     # via
     #   -r requirements/test.txt
     #   event-tracking
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   -r requirements/test.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
-    # via
-    #   -r requirements/test.txt
-    #   tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.5
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -87,7 +89,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -96,23 +98,23 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coverage[toml]==7.10.5
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via
     #   -r requirements/test.txt
     #   secretstorage
-dill==0.4.0
+dill==0.4.1
     # via pylint
 distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==4.2.23
+django==5.2.12
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-stubs
@@ -129,9 +131,9 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
-django-stubs==5.2.2
+django-stubs==5.2.9
     # via djangorestframework-stubs
-django-stubs-ext==5.2.2
+django-stubs-ext==5.2.9
     # via django-stubs
 django-waffle==5.0.0
     # via
@@ -140,13 +142,13 @@ django-waffle==5.0.0
     #   edx-toggles
 djangorestframework==3.16.1
     # via -r requirements/test.txt
-djangorestframework-stubs==3.16.2
+djangorestframework-stubs==3.16.8
     # via -r requirements/quality.in
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/test.txt
     #   pymongo
-docutils==0.22
+docutils==0.22.4
     # via
     #   -r requirements/test.txt
     #   readme-renderer
@@ -154,7 +156,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -162,12 +164,12 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/quality.in
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-search==4.1.3
+edx-search==4.4.0
     # via -r requirements/test.txt
 edx-toggles==5.4.1
     # via
@@ -176,37 +178,52 @@ edx-toggles==5.4.1
     #   event-tracking
 elasticsearch==7.13.4
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   edx-search
 event-tracking==3.3.0
     # via
     #   -r requirements/test.txt
     #   edx-search
-faker==37.6.0
+faker==40.8.0
     # via -r requirements/test.txt
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.25.0
     # via
     #   -r requirements/test.txt
+    #   python-discovery
     #   tox
     #   virtualenv
+h11==0.16.0
+    # via
+    #   -r requirements/test.txt
+    #   httpcore
+httpcore==1.0.9
+    # via
+    #   -r requirements/test.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -r requirements/test.txt
+    #   typesense
 id==1.5.0
     # via
     #   -r requirements/test.txt
     #   twine
-idna==3.10
+idna==3.11
     # via
     #   -r requirements/test.txt
+    #   anyio
+    #   httpx
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==6.0.1
+isort==8.0.1
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -214,11 +231,11 @@ jaraco-classes==3.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jaraco-functools==4.3.0
+jaraco-functools==4.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
@@ -231,19 +248,21 @@ jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
-keyring==25.6.0
+keyring==25.7.0
     # via
     #   -r requirements/test.txt
     #   twine
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/test.txt
     #   celery
+librt==0.8.1
+    # via mypy
 markdown-it-py==4.0.0
     # via
     #   -r requirements/test.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -253,24 +272,24 @@ mdurl==0.1.2
     # via
     #   -r requirements/test.txt
     #   markdown-it-py
-meilisearch==0.37.0
+meilisearch==0.40.0
     # via
     #   -r requirements/test.txt
     #   edx-search
 mongomock==4.3.0
     # via -r requirements/test.txt
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   -r requirements/test.txt
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.17.1
+mypy==1.19.1
     # via -r requirements/quality.in
 mypy-extensions==1.1.0
     # via mypy
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via -r requirements/test.txt
-nh3==0.3.0
+nh3==0.3.3
     # via
     #   -r requirements/test.txt
     #   readme-renderer
@@ -280,7 +299,7 @@ openedx-events==10.5.0
     # via
     #   -r requirements/test.txt
     #   event-tracking
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/test.txt
     #   build
@@ -290,12 +309,13 @@ packaging==25.0
     #   pytest
     #   tox
     #   twine
-pathspec==0.12.1
+pathspec==1.0.4
     # via mypy
-platformdirs==4.4.0
+platformdirs==4.9.4
     # via
     #   -r requirements/test.txt
     #   pylint
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -308,21 +328,21 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 pycodestyle==2.14.0
     # via -r requirements/quality.in
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via
     #   -r requirements/test.txt
     #   camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via
     #   -r requirements/test.txt
     #   pydantic
@@ -334,7 +354,7 @@ pygments==2.19.2
     #   pytest
     #   readme-renderer
     #   rich
-pylint==3.3.8
+pylint==4.0.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -342,22 +362,22 @@ pylint==3.3.8
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
 pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.1
+pymongo==4.16.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
     #   event-tracking
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -365,29 +385,33 @@ pyproject-hooks==1.2.0
     # via
     #   -r requirements/test.txt
     #   build
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/test.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   celery
+python-discovery==1.1.0
+    # via
+    #   -r requirements/test.txt
+    #   virtualenv
 python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   -r requirements/test.txt
     #   event-tracking
     #   mongomock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -398,12 +422,10 @@ readme-renderer==44.0
 requests==2.32.5
     # via
     #   -r requirements/test.txt
-    #   djangorestframework-stubs
     #   id
     #   meilisearch
     #   requests-toolbelt
     #   twine
-    #   typesense
 requests-toolbelt==1.0.0
     # via
     #   -r requirements/test.txt
@@ -412,11 +434,11 @@ rfc3986==2.0.0
     # via
     #   -r requirements/test.txt
     #   twine
-rich==14.1.0
+rich==14.3.3
     # via
     #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.3
+secretstorage==3.5.0
     # via
     #   -r requirements/test.txt
     #   keyring
@@ -433,15 +455,15 @@ six==1.17.0
     #   python-dateutil
 snowballstemmer==3.0.1
     # via pydocstyle
-soupsieve==2.8
+soupsieve==2.8.3
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.5.0
+stevedore==5.7.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -451,31 +473,36 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.3
+tomli-w==1.2.0
+    # via
+    #   -r requirements/test.txt
+    #   tox
+tomlkit==0.14.0
     # via pylint
-tox==4.28.4
+tox==4.49.0
     # via -r requirements/test.txt
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/test.txt
 types-beautifulsoup4==4.12.0.20250516
     # via -r requirements/quality.in
-types-html5lib==1.1.11.20250809
+types-html5lib==1.1.11.20251117
     # via types-beautifulsoup4
-types-pyyaml==6.0.12.20250822
+types-pyyaml==6.0.12.20250915
     # via
     #   django-stubs
     #   djangorestframework-stubs
 types-requests==2.31.0.6
-    # via
-    #   -r requirements/quality.in
-    #   djangorestframework-stubs
+    # via -r requirements/quality.in
 types-urllib3==1.26.25.14
     # via types-requests
-typesense==1.1.1
+types-webencodings==0.5.0.20251108
+    # via types-html5lib
+typesense==2.0.0
     # via -r requirements/test.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
+    #   anyio
     #   beautifulsoup4
     #   django-stubs
     #   django-stubs-ext
@@ -484,16 +511,20 @@ typing-extensions==4.15.0
     #   mypy
     #   pydantic
     #   pydantic-core
+    #   typesense
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via
     #   -r requirements/test.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/test.txt
-    #   faker
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
 urllib3==1.26.20
     # via
     #   -r requirements/test.txt
@@ -506,11 +537,11 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.1.0
     # via
     #   -r requirements/test.txt
     #   tox
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,49 +12,53 @@ annotated-types==0.7.0
     # via
     #   -r requirements/base.txt
     #   pydantic
-asgiref==3.9.1
+anyio==4.12.1
+    # via
+    #   -r requirements/base.txt
+    #   httpx
+asgiref==3.11.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.3
     # via -r requirements/base.txt
-billiard==4.2.1
+billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-build==1.3.0
+build==1.4.0
     # via -r requirements/test.in
-cachetools==6.2.0
+cachetools==7.0.3
     # via tox
-camel-converter[pydantic]==4.0.1
+camel-converter[pydantic]==5.1.0
     # via
     #   -r requirements/base.txt
     #   meilisearch
-celery==5.5.3
+celery==5.6.2
     # via
     #   -r requirements/base.txt
     #   event-tracking
-certifi==2025.8.3
+certifi==2026.2.25
     # via
     #   -r requirements/base.txt
     #   elasticsearch
+    #   httpcore
+    #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-chardet==5.2.0
-    # via tox
-charset-normalizer==3.4.3
+charset-normalizer==3.4.5
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.2.1
+click==8.3.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -75,21 +79,21 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
 colorama==0.4.6
     # via tox
-coverage[toml]==7.10.5
+coverage[toml]==7.13.4
     # via pytest-cov
-cryptography==45.0.6
+cryptography==46.0.5
     # via secretstorage
 distlib==0.4.0
     # via virtualenv
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-crum
     #   django-waffle
@@ -111,28 +115,28 @@ django-waffle==5.0.0
     #   edx-toggles
 djangorestframework==3.16.1
     # via -r requirements/base.txt
-dnspython==2.7.0
+dnspython==2.8.0
     # via
     #   -r requirements/base.txt
     #   pymongo
-docutils==0.22
+docutils==0.22.4
     # via readme-renderer
 edx-ccx-keys==2.0.2
     # via
     #   -r requirements/base.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
     #   edx-toggles
     #   event-tracking
     #   openedx-events
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-search==4.1.3
+edx-search==4.4.0
     # via -r requirements/base.txt
 edx-toggles==5.4.1
     # via
@@ -141,36 +145,51 @@ edx-toggles==5.4.1
     #   event-tracking
 elasticsearch==7.13.4
     # via
-    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-search
 event-tracking==3.3.0
     # via
     #   -r requirements/base.txt
     #   edx-search
-faker==37.6.0
+faker==40.8.0
     # via -r requirements/test.in
-fastavro==1.12.0
+fastavro==1.12.1
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.19.1
+filelock==3.25.0
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
-id==1.5.0
-    # via twine
-idna==3.10
+h11==0.16.0
     # via
     #   -r requirements/base.txt
+    #   httpcore
+httpcore==1.0.9
+    # via
+    #   -r requirements/base.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -r requirements/base.txt
+    #   typesense
+id==1.5.0
+    # via twine
+idna==3.11
+    # via
+    #   -r requirements/base.txt
+    #   anyio
+    #   httpx
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.0
     # via keyring
-jaraco-functools==4.3.0
+jaraco-functools==4.4.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -180,33 +199,33 @@ jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   code-annotations
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-kombu==5.5.4
+kombu==5.6.2
     # via
     #   -r requirements/base.txt
     #   celery
 markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-meilisearch==0.37.0
+meilisearch==0.40.0
     # via
     #   -r requirements/base.txt
     #   edx-search
 mongomock==4.3.0
     # via -r requirements/test.in
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mysqlclient==2.2.7
+mysqlclient==2.2.8
     # via -r requirements/base.txt
-nh3==0.3.0
+nh3==0.3.3
     # via readme-renderer
 openedx-atlas==0.7.0
     # via -r requirements/base.txt
@@ -214,7 +233,7 @@ openedx-events==10.5.0
     # via
     #   -r requirements/base.txt
     #   event-tracking
-packaging==25.0
+packaging==26.0
     # via
     #   -r requirements/base.txt
     #   build
@@ -224,8 +243,9 @@ packaging==25.0
     #   pytest
     #   tox
     #   twine
-platformdirs==4.4.0
+platformdirs==4.9.4
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -237,19 +257,19 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==7.0.0
+psutil==7.2.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via
     #   -r requirements/base.txt
     #   camel-converter
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via
     #   -r requirements/base.txt
     #   pydantic
@@ -258,41 +278,43 @@ pygments==2.19.2
     #   pytest
     #   readme-renderer
     #   rich
-pymongo==4.14.1
+pymongo==4.16.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
     #   event-tracking
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pyproject-api==1.9.1
+pyproject-api==1.10.0
     # via tox
 pyproject-hooks==1.2.0
     # via build
-pytest==8.4.1
+pytest==9.0.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via -r requirements/test.in
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   celery
+python-discovery==1.1.0
+    # via virtualenv
 python-slugify==8.0.4
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   -r requirements/base.txt
     #   event-tracking
     #   mongomock
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -305,14 +327,13 @@ requests==2.32.5
     #   meilisearch
     #   requests-toolbelt
     #   twine
-    #   typesense
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.1.0
+rich==14.3.3
     # via twine
-secretstorage==3.3.3
+secretstorage==3.5.0
     # via keyring
 sentinels==1.1.1
     # via mongomock
@@ -322,15 +343,15 @@ six==1.17.0
     #   edx-ccx-keys
     #   event-tracking
     #   python-dateutil
-soupsieve==2.8
+soupsieve==2.8.3
     # via
     #   -r requirements/base.txt
     #   beautifulsoup4
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.5.0
+stevedore==5.7.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -340,29 +361,36 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tox==4.28.4
+tomli-w==1.2.0
+    # via tox
+tox==4.49.0
     # via -r requirements/test.in
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/test.in
-typesense==1.1.1
+typesense==2.0.0
     # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
+    #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
+    #   typesense
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via
     #   -r requirements/base.txt
     #   pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via
     #   -r requirements/base.txt
-    #   faker
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
 urllib3==1.26.20
     # via
     #   -r requirements/base.txt
@@ -375,9 +403,9 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.34.0
+virtualenv==21.1.0
     # via tox
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 """
 Package metadata for forum.
 """
+
 import os
 import re
 import sys

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ setup(
     ),
     include_package_data=True,
     install_requires=load_requirements("requirements/base.in"),
-    python_requires=">=3.8",
+    python_requires=">=3.12",
     license="AGPL 3.0",
     zip_safe=False,
     keywords="Python edx",
@@ -174,7 +174,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={

--- a/tests/test_backends/test_mongodb/test_comments.py
+++ b/tests/test_backends/test_mongodb/test_comments.py
@@ -2,6 +2,7 @@
 """
 Tests for the `Comment` model.
 """
+
 from forum.backends.mongodb import Comment
 
 

--- a/tests/test_management/test_commands/test_migration_commands.py
+++ b/tests/test_management/test_commands/test_migration_commands.py
@@ -24,7 +24,6 @@ from forum.models import (
 )
 from forum.utils import get_trunc_title
 
-
 pytestmark = pytest.mark.django_db
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311, 312}-django{42,52},package
+envlist = py312-django{42,52},package
 
 [doc8]
 ; D001 = Line too long


### PR DESCRIPTION
## Summary

- Drop Python 3.11 support: remove from CI test matrix, tox envlist, and package classifiers
- Regenerate pinned requirements using Python 3.12
- Upgrade typesense-python 1.x → 2.0 and update import path accordingly
- Bump version to 0.4.0 (minor bump, covers breaking changes for 0.x per SemVer)

## ⚠️ Breaking: Typesense Server Version Requirement

typesense-python 2.0 requires **Typesense Server >= v30.0** (previously >= v28.0).
If you are running an older Typesense server you must upgrade it before deploying
this version of openedx-forum.

See the [typesense-python compatibility table](https://github.com/typesense/typesense-python#compatibility) for details.

## Context

Python 3.11 is being dropped across the Open edX ecosystem as part of the move
to standardize on Python 3.12. See the tracking issue for the full list of repos:
https://github.com/openedx/public-engineering/issues/499

## Test plan

- [ ] CI passes with Python 3.12 only
- [ ] Verify Typesense Server >= v30.0 is in use before deploying