### PR TITLE
feat: Add MySQL support for bulk APIs

### DIFF
--- a/forum/__init__.py
+++ b/forum/__init__.py
@@ -2,4 +2,4 @@
 Openedx forum app.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/forum/api/__init__.py
+++ b/forum/api/__init__.py
@@ -34,9 +34,11 @@ from .threads import (
 )
 from .users import (
     create_user,
+    delete_user_posts,
     get_user,
     get_user_active_threads,
     get_user_course_stats,
+    get_user_post_counts,
     mark_thread_as_read,
     retire_user,
     update_user,
@@ -61,6 +63,7 @@ __all__ = [
     "delete_subscription",
     "delete_thread",
     "delete_thread_vote",
+    "delete_user_posts",
     "get_commentables_stats",
     "get_course_id_by_comment",
     "get_course_id_by_thread",
@@ -71,6 +74,7 @@ __all__ = [
     "get_user_active_threads",
     "get_user_comments",
     "get_user_course_stats",
+    "get_user_post_counts",
     "get_user_subscriptions",
     "get_user_threads",
     "mark_thread_as_read",

--- a/forum/api/users.py
+++ b/forum/api/users.py
@@ -370,3 +370,21 @@ def update_users_in_course(course_id: str) -> dict[str, int]:
     backend = get_backend(course_id)()
     updated_users = backend.update_all_users_in_course(course_id)
     return {"user_count": len(updated_users)}
+
+
+def get_user_post_counts(user_id: str, course_id: str) -> dict[str, int]:
+    """Get count of threads and comments authored by user in course."""
+    backend = get_backend(course_id)()
+    user = backend.get_user(user_id)
+    if not user:
+        raise ForumV2RequestError(f"user not found with id: {user_id}")
+    return backend.get_user_post_counts(user_id, course_id)
+
+
+def delete_user_posts(user_id: str, course_id: str) -> dict[str, int]:
+    """Delete all threads and comments authored by user in course. Returns counts before deletion."""
+    backend = get_backend(course_id)()
+    user = backend.get_user(user_id)
+    if not user:
+        raise ForumV2RequestError(f"user not found with id: {user_id}")
+    return backend.delete_user_posts(user_id, course_id)

--- a/forum/backends/backend.py
+++ b/forum/backends/backend.py
@@ -476,3 +476,13 @@ class AbstractBackend:
         Retrieve all threads and comments authored by a specific user.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def get_user_post_counts(user_id: str, course_id: str) -> dict[str, int]:
+        """Return thread_count and comment_count for user in course."""
+        raise NotImplementedError
+
+    @staticmethod
+    def delete_user_posts(user_id: str, course_id: str) -> dict[str, int]:
+        """Delete all threads and comments by user in course. Returns counts before deletion."""
+        raise NotImplementedError

--- a/forum/backends/mongodb/api.py
+++ b/forum/backends/mongodb/api.py
@@ -1765,3 +1765,31 @@ class MongoBackend(AbstractBackend):
             CommentThread().find({"author_username": username})
         )
         return contents
+
+    @staticmethod
+    def get_user_post_counts(user_id: str, course_id: str) -> dict[str, int]:
+        """Return thread_count and comment_count for user in course."""
+        query = {"author_id": user_id, "course_id": course_id}
+        thread_count = CommentThread().count_documents(
+            {**query, "_type": "CommentThread"}
+        )
+        comment_count = Comment().count_documents({**query, "_type": "Comment"})
+        return {"thread_count": thread_count, "comment_count": comment_count}
+
+    @staticmethod
+    def delete_user_posts(user_id: str, course_id: str) -> dict[str, int]:
+        """Delete all threads and comments by user in course. Returns counts before deletion."""
+        thread_model = CommentThread()
+        comment_model = Comment()
+        query = {"author_id": user_id, "course_id": course_id}
+        thread_count = thread_model.count_documents({**query, "_type": "CommentThread"})
+        comment_count = comment_model.count_documents({**query, "_type": "Comment"})
+        # Collect IDs before deleting to avoid cursor invalidation.
+        # find() uses override_query which adds _type automatically.
+        comment_ids = [str(c["_id"]) for c in comment_model.find(query)]
+        for comment_id in comment_ids:
+            comment_model.delete(comment_id)
+        thread_ids = [str(t["_id"]) for t in thread_model.find(query)]
+        for thread_id in thread_ids:
+            thread_model.delete(thread_id)
+        return {"thread_count": thread_count, "comment_count": comment_count}

--- a/forum/backends/mysql/api.py
+++ b/forum/backends/mysql/api.py
@@ -2308,3 +2308,27 @@ class MySQLBackend(AbstractBackend):
             for thread in CommentThread.objects.filter(author__username=username)
         ]
         return contents
+
+    @staticmethod
+    def get_user_post_counts(user_id: str, course_id: str) -> dict[str, int]:
+        """Return thread_count and comment_count for user in course."""
+        thread_count = CommentThread.objects.filter(
+            author_id=user_id, course_id=course_id
+        ).count()
+        comment_count = Comment.objects.filter(
+            author_id=user_id, course_id=course_id
+        ).count()
+        return {"thread_count": thread_count, "comment_count": comment_count}
+
+    @staticmethod
+    def delete_user_posts(user_id: str, course_id: str) -> dict[str, int]:
+        """Delete all threads and comments by user in course. Returns counts before deletion."""
+        thread_count = CommentThread.objects.filter(
+            author_id=user_id, course_id=course_id
+        ).count()
+        comment_count = Comment.objects.filter(
+            author_id=user_id, course_id=course_id
+        ).count()
+        Comment.objects.filter(author_id=user_id, course_id=course_id).delete()
+        CommentThread.objects.filter(author_id=user_id, course_id=course_id).delete()
+        return {"thread_count": thread_count, "comment_count": comment_count}

--- a/forum/urls.py
+++ b/forum/urls.py
@@ -16,6 +16,7 @@ from forum.views.subscriptions import (
 )
 from forum.views.threads import CreateThreadAPIView, ThreadsAPIView, UserThreadsAPIView
 from forum.views.users import (
+    BulkDeleteUserPostsAPIView,
     UserActiveThreadsAPIView,
     UserAPIView,
     UserCourseStatsAPIView,
@@ -150,6 +151,11 @@ api_patterns = [
         "users/<str:user_id>/retire",
         UserRetireAPIView.as_view(),
         name="user-retire",
+    ),
+    path(
+        "users/<str:user_id>/posts",
+        BulkDeleteUserPostsAPIView.as_view(),
+        name="user-posts",
     ),
     # Proxy view for various API endpoints
     # Uncomment to redirect remaining API calls to the V1 API.

--- a/forum/views/users.py
+++ b/forum/views/users.py
@@ -13,8 +13,10 @@ from rest_framework.views import APIView
 from forum.api import get_user
 from forum.api.users import (
     create_user,
+    delete_user_posts,
     get_user_active_threads,
     get_user_course_stats,
+    get_user_post_counts,
     mark_thread_as_read,
     retire_user,
     update_user,
@@ -199,6 +201,38 @@ class UserActiveThreadsAPIView(APIView):
         except ForumV2RequestError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(serialized_data)
+
+
+class BulkDeleteUserPostsAPIView(APIView):
+    """Bulk count/delete user posts in a course."""
+
+    permission_classes = (AllowAny,)
+
+    def get(self, request: Request, user_id: str) -> Response:
+        """Return thread_count and comment_count for user in course."""
+        course_id = request.query_params.get("course_id")
+        if not course_id:
+            return Response(
+                {"error": "course_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        try:
+            data = get_user_post_counts(user_id, course_id)
+        except ForumV2RequestError as e:
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        return Response(data, status=status.HTTP_200_OK)
+
+    def delete(self, request: Request, user_id: str) -> Response:
+        """Delete all posts by user in course. Returns counts before deletion."""
+        course_id = request.query_params.get("course_id")
+        if not course_id:
+            return Response(
+                {"error": "course_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        try:
+            data = delete_user_posts(user_id, course_id)
+        except ForumV2RequestError as e:
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        return Response(data, status=status.HTTP_200_OK)
 
 
 class UserCourseStatsAPIView(APIView):

--- a/tests/test_views/test_users.py
+++ b/tests/test_views/test_users.py
@@ -507,3 +507,112 @@ def test_retire_user_with_subscribed_threads(
             assert content["title"] == RETIRED_TITLE
         assert content["body"] == RETIRED_BODY
         assert content["author_username"] == retired_username
+
+
+def test_get_user_post_counts(api_client: APIClient, patched_get_backend: Any) -> None:
+    """Test getting thread and comment counts for a user in a course."""
+    backend = patched_get_backend
+    user_id = backend.generate_id()
+    username = "test-user"
+    backend.find_or_create_user(user_id, username)
+    course_id = "course1"
+    # Create 3 threads and 1 comment per thread (3 comments total).
+    for i in range(3):
+        thread_id = backend.create_thread(
+            {
+                "title": f"Thread {i}",
+                "body": "body",
+                "course_id": course_id,
+                "commentable_id": "commentable1",
+                "author_id": user_id,
+                "author_username": username,
+            }
+        )
+        backend.create_comment(
+            {
+                "body": "comment body",
+                "course_id": course_id,
+                "author_id": user_id,
+                "comment_thread_id": str(thread_id),
+                "author_username": username,
+            }
+        )
+    response = api_client.get(f"/api/v2/users/{user_id}/posts?course_id={course_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["thread_count"] == 3
+    assert data["comment_count"] == 3
+
+
+def test_get_user_post_counts_missing_course_id(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
+    """Test that GET /users/<user_id>/posts returns 400 when course_id is missing."""
+    backend = patched_get_backend
+    user_id = backend.generate_id()
+    backend.find_or_create_user(user_id, "test-user")
+    response = api_client.get(f"/api/v2/users/{user_id}/posts")
+    assert response.status_code == 400
+
+
+def test_get_user_post_counts_invalid_user(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
+    """Test that GET /users/<user_id>/posts returns 404 for unknown user."""
+    backend = patched_get_backend
+    assert backend.get_user("999999") is None
+    response = api_client.get("/api/v2/users/999999/posts?course_id=course1")
+    assert response.status_code == 404
+
+
+def test_delete_user_posts(api_client: APIClient, patched_get_backend: Any) -> None:
+    """Test deleting all threads and comments by a user in a course."""
+    backend = patched_get_backend
+    user_id = backend.generate_id()
+    username = "test-user"
+    backend.find_or_create_user(user_id, username)
+    course_id = "course1"
+    thread_ids = []
+    for i in range(2):
+        thread_id = backend.create_thread(
+            {
+                "title": f"Thread {i}",
+                "body": "body",
+                "course_id": course_id,
+                "commentable_id": "commentable1",
+                "author_id": user_id,
+                "author_username": username,
+            }
+        )
+        backend.create_comment(
+            {
+                "body": "comment body",
+                "course_id": course_id,
+                "author_id": user_id,
+                "comment_thread_id": str(thread_id),
+                "author_username": username,
+            }
+        )
+        thread_ids.append(thread_id)
+    response = api_client.delete_json(
+        f"/api/v2/users/{user_id}/posts?course_id={course_id}"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["thread_count"] == 2
+    assert data["comment_count"] == 2
+    # Verify content is gone.
+    counts = api_client.get(f"/api/v2/users/{user_id}/posts?course_id={course_id}")
+    assert counts.json()["thread_count"] == 0
+    assert counts.json()["comment_count"] == 0
+
+
+def test_delete_user_posts_missing_course_id(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
+    """Test that DELETE /users/<user_id>/posts returns 400 when course_id is missing."""
+    backend = patched_get_backend
+    user_id = backend.generate_id()
+    backend.find_or_create_user(user_id, "test-user")
+    response = api_client.delete_json(f"/api/v2/users/{user_id}/posts")
+    assert response.status_code == 400


### PR DESCRIPTION
This PR adds new forum service APIs to count and bulk-delete all posts (threads + comments) authored by a user in a specific course.

close: #273 

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
