### PR TITLE
fix: order responses numerically by PK instead of lexicographically

### DIFF
--- a/forum/backends/mysql/models.py
+++ b/forum/backends/mysql/models.py
@@ -403,28 +403,29 @@ class Comment(Content):
         sort = kwargs.pop("sort", None)
         resp_skip = kwargs.pop("resp_skip", 0)
         resp_limit = kwargs.pop("resp_limit", None)
-        comments = Comment.objects.filter(**kwargs)
-        result = []
-        if sort:
-            if sort == 1:
-                result = sorted(
-                    comments, key=lambda x: (x.sort_key is None, x.sort_key or "")
-                )
-            elif sort == -1:
-                result = sorted(
-                    comments,
-                    key=lambda x: (x.sort_key is None, x.sort_key or ""),
-                    reverse=True,
-                )
+        comments_qs = Comment.objects.filter(**kwargs)
 
-        paginated_comments = result or list(comments)
+        # Order by primary key, which is monotonically increasing with creation
+        # time. The previous implementation sorted by `sort_key`, a CharField
+        # containing the PK rendered as a string ("10" < "2" lexicographically),
+        # which produced an interleaved order that looked like sorting was not
+        # being applied at all.
+        # See https://github.com/openedx/frontend-app-discussions/issues/823
+        if sort == -1:
+            comments_qs = comments_qs.order_by("-pk")
+        else:
+            # Treat sort == 1 and the unsorted/None case the same way: ascending
+            # by PK. The legacy "no sort" path silently returned no rows when
+            # `resp_limit` was set (because pagination indexed into an empty
+            # `result` list); using a deterministic order fixes that too.
+            comments_qs = comments_qs.order_by("pk")
 
-        # Apply pagination if resp_limit is provided
         if resp_limit is not None:
-            resp_end = resp_skip + resp_limit
-            paginated_comments = result[resp_skip:resp_end]
-        elif resp_skip:  # If resp_limit is None but resp_skip is provided
-            paginated_comments = result[resp_skip:]
+            paginated_comments = list(comments_qs[resp_skip:resp_skip + resp_limit])
+        elif resp_skip:
+            paginated_comments = list(comments_qs[resp_skip:])
+        else:
+            paginated_comments = list(comments_qs)
 
         return [content.to_dict() for content in paginated_comments]
 


### PR DESCRIPTION
## Summary

`Comment.get_list()` sorted responses by `sort_key`, a `CharField` that holds the comment's primary key rendered as a string. String comparison gives the lexicographic order `\"1\", \"10\", \"11\", \"12\", \"2\", \"3\", …` instead of the numeric `1, 2, 3, …, 12`. To users this looks as though the response sort dropdown does nothing — picking *Newest first* or *Oldest first* produces what appears to be a random shuffle.

This change orders comments at the database layer by integer PK (`pk` is monotonic with creation time, so PK ascending == oldest first).

Fixes [openedx/frontend-app-discussions#823](https://github.com/openedx/frontend-app-discussions/issues/823).  
Discuss thread (same user reporting): https://discuss.openedx.org/t/discuss-forum-messages-order-not-organized-as-expected-in-teak/18665

## What changed

In [\`forum/backends/mysql/models.py\`](https://github.com/openedx/forum/blob/master/forum/backends/mysql/models.py), \`Comment.get_list()\`:

- **Before:** Pulled all comments into Python and called \`sorted(..., key=lambda x: (x.sort_key is None, x.sort_key or \"\"))\` — string sort.
- **After:** Uses Django's \`queryset.order_by(\"pk\")\` / \`order_by(\"-pk\")\` so MySQL does the ordering numerically.

Behaviour for the two documented inputs is preserved:
- \`sort == 1\` (ascending / *Oldest first*) → \`order_by(\"pk\")\`
- \`sort == -1\` (descending / *Newest first*) → \`order_by(\"-pk\")\`
- \`sort is None\` (legacy unsorted call) → now also \`order_by(\"pk\")\`. This is a behaviour change but fixes a latent bug: when \`sort=None\` *and* \`resp_limit\` was set, the old code sliced into an empty \`result\` list and returned **no rows** at all. The new code returns a deterministic page.

## Why not fix \`get_sort_key\` to be int-safe instead?

\`sort_key\` is a denormalised \`CharField\` of the form \`\"{pk}\"\` or \`\"{parent_pk}-{pk}\"\`. Sorting by PK avoids the field entirely, removes a Python-level pass over every result, and pushes ordering to the database (so pagination via \`[resp_skip:resp_end]\` runs against an already-sorted queryset instead of a list slice).

## Endorsed/answered responses

The reporter notes that endorsed/answer responses should remain on top regardless of sort. That separation is handled one layer up in edx-platform [\`lms/djangoapps/discussion/rest_api/api.py\`](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/discussion/rest_api/api.py) for question threads (\`endorsed_responses\` + \`non_endorsed_responses\`). Not in scope for this fix.

## Test plan

- [x] Local Tutor dev (\`forum_v2.enable_mysql_backend\` on) — created a thread with 12+ responses; sort dropdown now produces correct numeric order in both directions.
- [ ] Suggested follow-up unit test: in \`tests/test_backends/test_mysql/test_comments.py\` create ≥10 comments and assert \`Comment.get_list(sort=1, comment_thread=…)\` returns ascending PK order (not lex order). Happy to add it in this PR if reviewers prefer it bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)