### PR TITLE
fix: Correct the build command.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ fallback_version = "0.0.0.dev0"
 [tool.semantic_release]
 # Use SETUPTOOLS_SCM_PRETEND_VERSION to set version at build time since the
 # build step happens before the repo gets tagged.
-build_command = "uv run --with build SETUPTOOLS_SCM_PRETEND_VERSION=$NEW_VERSION python -m build"
+build_command = "pip install build && SETUPTOOLS_SCM_PRETEND_VERSION=$NEW_VERSION python -m build"
 # Repo is on 0.x: prevent a feat: commit from bumping 0.x.y → 1.0.0
 allow_zero_version = true
 major_on_zero = false


### PR DESCRIPTION
The build command is run within a 3rd party pypi action.  That action
has access to pip but not to uv so we need to run pip commands directly
not via `uv`.
