### PR TITLE
fix: Fix a typo in the readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ To try out changes before applying them, use the ``--dry-run`` option. For insta
 
    ./manage.py lms forum_delete_course_from_mongodb all --dry-run
 
-Search Indicies
----------------
+Search Indices
+--------------
 
 Based on your search backend i.e Elasticsearch or Meilisearch, the commands will populate search indexes.
 


### PR DESCRIPTION
This would normally be a docs fix but making it a `fix` type so that we
can test the new semantic release tooling is working correctly.
